### PR TITLE
Make secret values resolvable from env-vars

### DIFF
--- a/steps.go
+++ b/steps.go
@@ -37,7 +37,7 @@ func localhostEnterpriseConfig(secret string) enterprise.ActivateRequest {
 }
 
 func licenseStep(_ *client.APIClient, ec *client.APIClient) error {
-	key, err := skipIfNotExist(licensePath)
+	key, err := skipIfNotExistResolvable(licensePath)
 	if err != nil {
 		return err
 	}

--- a/steps.go
+++ b/steps.go
@@ -49,7 +49,7 @@ func licenseStep(_ *client.APIClient, ec *client.APIClient) error {
 }
 
 func enterpriseSecretStep(_ *client.APIClient, ec *client.APIClient) error {
-	secret, err := skipIfNotExist(enterpriseSecretPath)
+	secret, err := skipIfNotExistResolvable(enterpriseSecretPath)
 	if err != nil {
 		return err
 	}
@@ -73,6 +73,13 @@ func syncEnterpriseClusters(ec *client.APIClient, clusters []license.AddClusterR
 		} else {
 			cluster.ClusterDeploymentId = v
 		}
+
+		if v, err := resolveIfEnvVar(cluster.Secret); err != nil {
+			return err
+		} else {
+			cluster.Secret = v
+		}
+
 		if _, err := ec.License.AddCluster(ec.Ctx(), &cluster); err != nil {
 			if !license.IsErrDuplicateClusterID(err) {
 				return err
@@ -219,6 +226,12 @@ func enterpriseConfigStep(c *client.APIClient, _ *client.APIClient) error {
 		return err
 	}
 
+	if v, err := resolveIfEnvVar(config.Secret); err != nil {
+		return err
+	} else {
+		config.Secret = v
+	}
+
 	_, err := c.Enterprise.Activate(c.Ctx(), &config)
 	return err
 }
@@ -227,6 +240,12 @@ func authConfigStep(c *client.APIClient, _ *client.APIClient) error {
 	var config auth.OIDCConfig
 	if err := loadYAML(authConfigPath, &config); err != nil {
 		return err
+	}
+
+	if cs, err := resolveIfEnvVar(config.ClientSecret); err != nil {
+		return err
+	} else {
+		config.ClientSecret = cs
 	}
 
 	_, err := c.SetConfiguration(c.Ctx(), &auth.SetConfigurationRequest{Configuration: &config})

--- a/util.go
+++ b/util.go
@@ -29,12 +29,24 @@ func skipIfNotExist(path string) ([]byte, error) {
 	return data, nil
 }
 
+func skipIfNotExistResolvable(path string) ([]byte, error) {
+	v, err := skipIfNotExist(path)
+	if err != nil {
+		return nil, err
+	}
+	vStr, err := resolveIfEnvVar(string(v))
+	if err != nil {
+		return nil, err
+	}
+	return []byte(vStr), nil
+}
+
 func loadRootToken() ([]byte, error) {
-	return skipIfNotExist(rootTokenPath)
+	return skipIfNotExistResolvable(rootTokenPath)
 }
 
 func loadEnterpriseRootToken() ([]byte, error) {
-	return skipIfNotExist(enterpriseRootTokenPath)
+	return skipIfNotExistResolvable(enterpriseRootTokenPath)
 }
 
 func loadEnterpriseServerAddress() ([]byte, error) {

--- a/util.go
+++ b/util.go
@@ -58,7 +58,11 @@ func loadYAML(path string, target interface{}) error {
 	if err != nil {
 		return err
 	}
-	return yaml.Unmarshal(data, &target)
+	s, err := resolveIfEnvVar(string(data))
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal([]byte(s), &target)
 }
 
 func resolveIfEnvVar(v string) (string, error) {


### PR DESCRIPTION
The following values are now resolved to their env-var value if pre-fixed with "$":
- `authConfig.client_secret`
- `oidcClients[i].secret`
- `enterpriseClusters[i].secret`
- `enterpriseConfig.secret`
- `enterpriseSecret`
- `rootToken`
- `enterpriseRootToken`