### PR TITLE
Add golang-lint to the config pod CI and fix all lint warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,25 +3,9 @@ version: 2.1
 jobs:
   lint:
     docker:
-      - image: circleci/golang:1.16
+      - image: golangci/golangci-lint:v1.43.0
     steps: # steps that comprise the `build` job
       - checkout # check out source code to working directory
-      - run: "echo $(($(date +%s)/604800)) > current_week"
-      - restore_cache:
-          key: golang-lint-ci-{{ checksum "current_week" }}
-      - run:
-          name: install lint
-          command: |
-            if [[ ! -e /usr/local/bin/golangci-lint ]]; then
-              cd /usr/local
-              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-                | sudo sh -s v1.40.1
-              sudo chmod 755 ./bin/golangci-lint
-            fi
-      - save_cache:
-          paths:
-            - /usr/local/bin/golangci-lint
-          key: golang-lint-ci-{{ checksum "current_week" }}
       - run:
           name: run lint
           command: golangci-lint run --timeout 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,30 @@
 version: 2.1
 
 jobs:
+  lint:
+    docker:
+      - image: circleci/golang:1.16
+    steps: # steps that comprise the `build` job
+      - checkout # check out source code to working directory
+      - run: "echo $(($(date +%s)/604800)) > current_week"
+      - restore_cache:
+          key: golang-lint-ci-{{ checksum "current_week" }}
+      - run:
+          name: install lint
+          command: |
+            if [[ ! -e /usr/local/bin/golangci-lint ]]; then
+              cd /usr/local
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+                | sh -s v1.40.1
+            fi
+      - save_cache:
+          paths:
+            - /usr/local/bin/golangci-lint
+          key: golang-lint-ci-{{ checksum "current_week" }}
+      - run:
+          name: run lint
+          command: golangci-lint run --timeout 10m
+
   test:
     resource_class: large
     machine:
@@ -28,6 +52,7 @@ jobs:
 workflows:
   circleci:
     jobs:
+      - lint
       - test:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,8 @@ jobs:
             if [[ ! -e /usr/local/bin/golangci-lint ]]; then
               cd /usr/local
               curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-                | sh -s v1.40.1
+                | sudo sh -s v1.40.1
+              sudo chmod 755 ./bin/golangci-lint
             fi
       - save_cache:
           paths:

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.15
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/jackc/pgx/v4 v4.13.0 // indirect
 	github.com/json-iterator/go v1.1.11 // indirect
-	github.com/pachyderm/pachyderm/v2 v2.0.0-proxy.1.0.20210920125805-e15847c0076a
+	github.com/pachyderm/pachyderm/v2 v2.0.5
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e // indirect

--- a/go.sum
+++ b/go.sum
@@ -849,6 +849,8 @@ github.com/pachyderm/ohmyglob v0.0.0-20210308211843-d5b47775fc36 h1:BYlMmKAikMso
 github.com/pachyderm/ohmyglob v0.0.0-20210308211843-d5b47775fc36/go.mod h1:zTTB59W9i3MPZor62iS6A5hL1rbPCKDLPo/CetUPLuQ=
 github.com/pachyderm/pachyderm/v2 v2.0.0-proxy.1.0.20210920125805-e15847c0076a h1:n6Uw5FflRvxHZpz7wiziexQZqYRJpBFj3vRFVz+T1os=
 github.com/pachyderm/pachyderm/v2 v2.0.0-proxy.1.0.20210920125805-e15847c0076a/go.mod h1:pSA1DEQdI6TWZ/njPFjTEFF30cgnRHH+w1+mHvuIW+Q=
+github.com/pachyderm/pachyderm/v2 v2.0.5 h1:d3rjB9HZkZgKNvWLbDmi1V/9YTAXGhBaNiZbuc59a24=
+github.com/pachyderm/pachyderm/v2 v2.0.5/go.mod h1:ibpkiA/VYFtvruhsnJK+vPQpyHaojBrhCRXu0VHSZEA=
 github.com/pachyderm/s2 v0.0.0-20190725181334-d1f4a476d240/go.mod h1:ElO4u0RXSPaw9RGOyFafJ9GzaWS1bteLwywxyduiGNU=
 github.com/pachyderm/s2 v0.0.0-20200609183354-d52f35094520/go.mod h1:+bgy+pTTvgUhcIKkb1Qj4kBFvsRvw0OOySSYmJHz/IQ=
 github.com/pachyderm/s2/examples/sql v0.0.0-20200528231500-590b33e3c716/go.mod h1:rDwxgIkpsabZLa85PCS2MwkFSl/HgmHfc5XHJKiPuiE=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ const (
 	idpsPath                  = "idps"
 	oidcClientsPath           = "oidcClients"
 	authConfigPath            = "authConfig"
-	authPath                  = "auth"
 )
 
 // the 1st client represents the pachd instance that needs to register with an enterprise server represented by the 2nd argument ("ec")

--- a/main.go
+++ b/main.go
@@ -102,7 +102,9 @@ func main() {
 				stepLogger.WithError(err).Error("error syncing cluster state")
 				os.Exit(1)
 			}
-			stepLogger.WithField("reason", err).Info("skipped")
+			stepLogger.WithField("reason", err).Warn("skipped")
+		} else {
+			stepLogger.Info("success")
 		}
 	}
 }

--- a/steps_test.go
+++ b/steps_test.go
@@ -76,7 +76,7 @@ func (s *StepTestSuite) SetupSuite() {
 }
 
 func (s *StepTestSuite) SetupTest() {
-	s.c.DeleteAll()
+	s.Require().NoError(s.c.DeleteAll())
 	var err error
 	configRoot, err = ioutil.TempDir("", "example")
 	s.Require().NoError(err)
@@ -116,7 +116,7 @@ func (s *StepTestSuite) TestSimpleConfig() {
 	s.writeSimpleConfig()
 
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	// check that we're authenticated as the root user and auth is active
@@ -153,7 +153,7 @@ func (s *StepTestSuite) TestFullConfig() {
 	s.writeYAML(authConfigPath, oidcConfig)
 
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	authConfig, err := s.c.GetConfiguration(s.c.Ctx(), &auth.GetConfigurationRequest{})
@@ -170,7 +170,7 @@ func (s *StepTestSuite) TestRoleBindings() {
 	})
 
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	roleBinding, err := s.c.GetRoleBinding(s.c.Ctx(), &auth.GetRoleBindingRequest{
@@ -187,7 +187,7 @@ func (s *StepTestSuite) TestRoleBindings() {
 	})
 
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	roleBinding, err = s.c.GetRoleBinding(s.c.Ctx(), &auth.GetRoleBindingRequest{
@@ -215,7 +215,7 @@ func (s *StepTestSuite) TestIDPs() {
 	s.writeYAML(idpsPath, []identity.IDPConnector{mockIDPConnector})
 
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	idps, err := s.c.ListIDPConnectors(s.c.Ctx(), &identity.ListIDPConnectorsRequest{})
@@ -227,7 +227,7 @@ func (s *StepTestSuite) TestIDPs() {
 
 	s.writeYAML(idpsPath, []identity.IDPConnector{mockIDPConnector})
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	idps, err = s.c.ListIDPConnectors(s.c.Ctx(), &identity.ListIDPConnectorsRequest{})
@@ -262,7 +262,7 @@ func (s *StepTestSuite) TestOIDCClients() {
 
 	s.writeYAML(oidcClientsPath, []identity.OIDCClient{pachydermOIDCClient, newClient, newClientWithEnvVarSecret})
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	clients, err := s.c.ListOIDCClients(s.c.Ctx(), &identity.ListOIDCClientsRequest{})
@@ -276,7 +276,7 @@ func (s *StepTestSuite) TestOIDCClients() {
 
 	s.writeYAML(oidcClientsPath, []identity.OIDCClient{newClient})
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	clients, err = s.c.ListOIDCClients(s.c.Ctx(), &identity.ListOIDCClientsRequest{})
@@ -304,7 +304,7 @@ func (s *StepTestSuite) TestEnterpriseConfig() {
 	})
 
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	clusters, err := s.c.License.ListClusters(s.c.Ctx(), &license.ListClustersRequest{})
@@ -330,7 +330,7 @@ func (s *StepTestSuite) TestEnterpriseConfig() {
 
 	s.writeYAML(enterpriseClustersPath, []license.AddClusterRequest{updatedCluster, newCluster})
 	for _, step := range syncSteps {
-		step.fn(s.c, s.c)
+		s.Require().NoError(step.fn(s.c, s.c))
 	}
 
 	clusters, err = s.c.License.ListClusters(s.c.Ctx(), &license.ListClustersRequest{})

--- a/steps_test.go
+++ b/steps_test.go
@@ -53,6 +53,11 @@ type StepTestSuite struct {
 	c *client.APIClient
 }
 
+func (s *StepTestSuite) RequireNilOrSkipped(err error) {
+	s.T().Helper()
+	s.Require().True(err == nil || errors.Is(err, errSkipped))
+}
+
 func (s *StepTestSuite) writeFile(filename string, data []byte) {
 	s.Require().NoError(ioutil.WriteFile(path.Join(configRoot, filename), data, os.ModePerm))
 }
@@ -86,7 +91,7 @@ func (s *StepTestSuite) SetupTest() {
 func (s *StepTestSuite) TestSkipStep() {
 	for _, step := range syncSteps {
 		err := step.fn(s.c, s.c)
-		s.Require().True(errors.Is(err, errSkipped))
+		s.Require().ErrorIs(err, errSkipped)
 	}
 }
 
@@ -116,7 +121,7 @@ func (s *StepTestSuite) TestSimpleConfig() {
 	s.writeSimpleConfig()
 
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	// check that we're authenticated as the root user and auth is active
@@ -153,7 +158,7 @@ func (s *StepTestSuite) TestFullConfig() {
 	s.writeYAML(authConfigPath, oidcConfig)
 
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	authConfig, err := s.c.GetConfiguration(s.c.Ctx(), &auth.GetConfigurationRequest{})
@@ -170,7 +175,7 @@ func (s *StepTestSuite) TestRoleBindings() {
 	})
 
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	roleBinding, err := s.c.GetRoleBinding(s.c.Ctx(), &auth.GetRoleBindingRequest{
@@ -187,7 +192,7 @@ func (s *StepTestSuite) TestRoleBindings() {
 	})
 
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	roleBinding, err = s.c.GetRoleBinding(s.c.Ctx(), &auth.GetRoleBindingRequest{
@@ -215,7 +220,7 @@ func (s *StepTestSuite) TestIDPs() {
 	s.writeYAML(idpsPath, []identity.IDPConnector{mockIDPConnector})
 
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	idps, err := s.c.ListIDPConnectors(s.c.Ctx(), &identity.ListIDPConnectorsRequest{})
@@ -227,7 +232,7 @@ func (s *StepTestSuite) TestIDPs() {
 
 	s.writeYAML(idpsPath, []identity.IDPConnector{mockIDPConnector})
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	idps, err = s.c.ListIDPConnectors(s.c.Ctx(), &identity.ListIDPConnectorsRequest{})
@@ -262,7 +267,7 @@ func (s *StepTestSuite) TestOIDCClients() {
 
 	s.writeYAML(oidcClientsPath, []identity.OIDCClient{pachydermOIDCClient, newClient, newClientWithEnvVarSecret})
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	clients, err := s.c.ListOIDCClients(s.c.Ctx(), &identity.ListOIDCClientsRequest{})
@@ -276,7 +281,7 @@ func (s *StepTestSuite) TestOIDCClients() {
 
 	s.writeYAML(oidcClientsPath, []identity.OIDCClient{newClient})
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	clients, err = s.c.ListOIDCClients(s.c.Ctx(), &identity.ListOIDCClientsRequest{})
@@ -304,7 +309,7 @@ func (s *StepTestSuite) TestEnterpriseConfig() {
 	})
 
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	clusters, err := s.c.License.ListClusters(s.c.Ctx(), &license.ListClustersRequest{})
@@ -330,7 +335,7 @@ func (s *StepTestSuite) TestEnterpriseConfig() {
 
 	s.writeYAML(enterpriseClustersPath, []license.AddClusterRequest{updatedCluster, newCluster})
 	for _, step := range syncSteps {
-		s.Require().NoError(step.fn(s.c, s.c))
+		s.RequireNilOrSkipped(step.fn(s.c, s.c))
 	}
 
 	clusters, err = s.c.License.ListClusters(s.c.Ctx(), &license.ListClustersRequest{})


### PR DESCRIPTION
This was precipitated by https://pachyderm.slack.com/archives/CSELV66P5/p1640124036326000, where the dropped error in `steps.go` caused an invalid config to fail silently, leading to some user confusion.

This PR fixes the dropped error, adds some basic linting that could catch that class of errors, and then fixes all the other lint errors (which are all in tests).

Other changes in this PR:
- Upgrade the pach dependency to 2.0.5 (unrelated to the other changes, but small :grimacing:)
- return `errSkipped` if an IDP config update is a no-op because the config isn't changed. Also, report skipped steps in the logs. 